### PR TITLE
feat: introduced a way to lerverage original casing for request headers

### DIFF
--- a/src/client/conn/http1.rs
+++ b/src/client/conn/http1.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
+use std::collections::HashMap;
 
 use crate::rt::{Read, Write};
 use bytes::Bytes;
@@ -112,6 +113,7 @@ pub struct Builder {
     h1_parser_config: ParserConfig,
     h1_writev: Option<bool>,
     h1_title_case_headers: bool,
+    h1_origin_header_names: Option<HashMap<String, String>>,
     h1_preserve_header_case: bool,
     h1_max_headers: Option<usize>,
     #[cfg(feature = "ffi")]
@@ -312,6 +314,7 @@ impl Builder {
             h1_read_buf_exact_size: None,
             h1_parser_config: Default::default(),
             h1_title_case_headers: false,
+            h1_origin_header_names: None,
             h1_preserve_header_case: false,
             h1_max_headers: None,
             #[cfg(feature = "ffi")]
@@ -428,6 +431,12 @@ impl Builder {
         self
     }
 
+    /// Set hashmap for origin header names.
+    pub fn origin_header_names(&mut self, names: HashMap<String, String>) -> &mut Builder {
+        self.h1_origin_header_names = Some(names);
+        self
+    }
+
     /// Set whether to support preserving original header cases.
     ///
     /// Currently, this will record the original cases received, and store them
@@ -538,6 +547,9 @@ impl Builder {
             }
             if opts.h1_title_case_headers {
                 conn.set_title_case_headers();
+            }
+            if let Some(origin_header_names) = opts.h1_origin_header_names {
+                conn.set_origin_header_names(origin_header_names);
             }
             if opts.h1_preserve_header_case {
                 conn.set_preserve_header_case();

--- a/src/proto/h1/conn.rs
+++ b/src/proto/h1/conn.rs
@@ -4,6 +4,7 @@ use std::future::Future;
 use std::io;
 use std::marker::{PhantomData, Unpin};
 use std::pin::Pin;
+use std::collections::HashMap;
 use std::task::{Context, Poll};
 #[cfg(feature = "server")]
 use std::time::{Duration, Instant};
@@ -72,6 +73,7 @@ where
                 #[cfg(feature = "ffi")]
                 preserve_header_order: false,
                 title_case_headers: false,
+                origin_header_names: None,
                 h09_responses: false,
                 #[cfg(feature = "ffi")]
                 on_informational: None,
@@ -122,6 +124,10 @@ where
 
     pub(crate) fn set_title_case_headers(&mut self) {
         self.state.title_case_headers = true;
+    }
+
+    pub(crate) fn set_origin_header_names(&mut self, origin_header_names: HashMap<String, String>) {
+        self.state.origin_header_names = Some(origin_header_names);
     }
 
     pub(crate) fn set_preserve_header_case(&mut self) {
@@ -626,6 +632,7 @@ where
                 keep_alive: self.state.wants_keep_alive(),
                 req_method: &mut self.state.method,
                 title_case_headers: self.state.title_case_headers,
+                origin_header_names: self.state.origin_header_names.clone(),
                 #[cfg(feature = "server")]
                 date_header: self.state.date_header,
             },
@@ -736,7 +743,7 @@ where
         match self.state.writing {
             Writing::Body(ref encoder) => {
                 if let Some(enc_buf) =
-                    encoder.encode_trailers(trailers, self.state.title_case_headers)
+                    encoder.encode_trailers(trailers, self.state.title_case_headers, self.state.origin_header_names.clone())
                 {
                     self.io.buffer(enc_buf);
 
@@ -939,6 +946,7 @@ struct State {
     #[cfg(feature = "ffi")]
     preserve_header_order: bool,
     title_case_headers: bool,
+    origin_header_names: Option<HashMap<String, String>>,
     h09_responses: bool,
     /// If set, called with each 1xx informational response received for
     /// the current request. MUST be unset after a non-1xx response is

--- a/src/proto/h1/encode.rs
+++ b/src/proto/h1/encode.rs
@@ -164,6 +164,7 @@ impl Encoder {
         &self,
         trailers: HeaderMap,
         title_case_headers: bool,
+        origin_header_names: Option<HashMap<String, String>>,
     ) -> Option<EncodedBuf<B>> {
         trace!("encoding trailers");
         match &self.kind {
@@ -194,7 +195,7 @@ impl Encoder {
                 if title_case_headers {
                     write_headers_title_case(&allowed_trailers, &mut buf);
                 } else {
-                    write_headers(&allowed_trailers, &mut buf);
+                    write_headers(&allowed_trailers, &mut buf, origin_header_names);
                 }
 
                 if buf.is_empty() {
@@ -546,7 +547,7 @@ mod tests {
             ),
         ]);
 
-        let buf1 = encoder.encode_trailers::<&[u8]>(headers, false).unwrap();
+        let buf1 = encoder.encode_trailers::<&[u8]>(headers, false, None).unwrap();
 
         let mut dst = Vec::new();
         dst.put(buf1);
@@ -573,7 +574,7 @@ mod tests {
             ),
         ]);
 
-        let buf1 = encoder.encode_trailers::<&[u8]>(headers, false).unwrap();
+        let buf1 = encoder.encode_trailers::<&[u8]>(headers, false, None).unwrap();
 
         let mut dst = Vec::new();
         dst.put(buf1);
@@ -593,13 +594,13 @@ mod tests {
         )]);
 
         assert!(encoder
-            .encode_trailers::<&[u8]>(headers.clone(), false)
+            .encode_trailers::<&[u8]>(headers.clone(), false, None)
             .is_none());
 
         let trailers = vec![];
         let encoder = encoder.into_chunked_with_trailing_fields(trailers);
 
-        assert!(encoder.encode_trailers::<&[u8]>(headers, false).is_none());
+        assert!(encoder.encode_trailers::<&[u8]>(headers, false, None).is_none());
     }
 
     #[test]
@@ -638,7 +639,7 @@ mod tests {
         headers.insert(TRANSFER_ENCODING, HeaderValue::from_static("header data"));
         headers.insert(TE, HeaderValue::from_static("header data"));
 
-        assert!(encoder.encode_trailers::<&[u8]>(headers, true).is_none());
+        assert!(encoder.encode_trailers::<&[u8]>(headers, true, None).is_none());
     }
 
     #[test]
@@ -651,7 +652,7 @@ mod tests {
             HeaderName::from_static("chunky-trailer"),
             HeaderValue::from_static("header data"),
         )]);
-        let buf1 = encoder.encode_trailers::<&[u8]>(headers, true).unwrap();
+        let buf1 = encoder.encode_trailers::<&[u8]>(headers, true, None).unwrap();
 
         let mut dst = Vec::new();
         dst.put(buf1);

--- a/src/proto/h1/mod.rs
+++ b/src/proto/h1/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use bytes::BytesMut;
 use http::{HeaderMap, Method};
 use httparse::ParserConfig;
@@ -89,6 +91,7 @@ pub(crate) struct Encode<'a, T> {
     keep_alive: bool,
     req_method: &'a mut Option<Method>,
     title_case_headers: bool,
+    origin_header_names: Option<HashMap<String, String>>,
     #[cfg(feature = "server")]
     date_header: bool,
 }

--- a/src/proto/h1/role.rs
+++ b/src/proto/h1/role.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::mem::MaybeUninit;
 
 #[cfg(feature = "client")]
@@ -1208,7 +1209,7 @@ impl Http1Transaction for Client {
         } else if msg.title_case_headers {
             write_headers_title_case(&msg.head.headers, dst);
         } else {
-            write_headers(&msg.head.headers, dst);
+            write_headers(&msg.head.headers, dst, msg.origin_header_names);
         }
 
         extend(dst, b"\r\n");
@@ -1563,6 +1564,7 @@ fn title_case(dst: &mut Vec<u8>, name: &[u8]) {
 
 pub(crate) fn write_headers_title_case(headers: &HeaderMap, dst: &mut Vec<u8>) {
     for (name, value) in headers {
+        println!("name: {:?}", name.as_str());
         title_case(dst, name.as_str().as_bytes());
         extend(dst, b": ");
         extend(dst, value.as_bytes());
@@ -1570,9 +1572,21 @@ pub(crate) fn write_headers_title_case(headers: &HeaderMap, dst: &mut Vec<u8>) {
     }
 }
 
-pub(crate) fn write_headers(headers: &HeaderMap, dst: &mut Vec<u8>) {
+pub(crate) fn write_headers(headers: &HeaderMap, dst: &mut Vec<u8>, origin_header_names: Option<HashMap<String, String>>) {
     for (name, value) in headers {
-        extend(dst, name.as_str().as_bytes());
+        if let Some(origin_header_names) = &origin_header_names {
+            println!("origin_header_names was provided");
+            if let Some(original_name) = origin_header_names.get(name.as_str()) {
+                println!("writing original name for header: {:?}", original_name);
+                extend(dst, original_name.as_bytes());
+            } else {
+                println!("writing lowercase: {:?}", name.as_str());
+                extend(dst, name.as_str().as_bytes());
+            }
+        } else {
+            println!("origin_header_names was not provided");
+            extend(dst, name.as_str().as_bytes());
+        }
         extend(dst, b": ");
         extend(dst, value.as_bytes());
         extend(dst, b"\r\n");
@@ -2466,6 +2480,7 @@ mod tests {
                 keep_alive: true,
                 req_method: &mut None,
                 title_case_headers: true,
+                origin_header_names: None,
                 #[cfg(feature = "server")]
                 date_header: true,
             },
@@ -2500,6 +2515,7 @@ mod tests {
                 keep_alive: true,
                 req_method: &mut None,
                 title_case_headers: false,
+                origin_header_names: None,
                 #[cfg(feature = "server")]
                 date_header: true,
             },
@@ -2537,6 +2553,7 @@ mod tests {
                 keep_alive: true,
                 req_method: &mut None,
                 title_case_headers: true,
+                origin_header_names: None,
                 #[cfg(feature = "server")]
                 date_header: true,
             },
@@ -2564,6 +2581,7 @@ mod tests {
                 keep_alive: true,
                 req_method: &mut Some(Method::CONNECT),
                 title_case_headers: false,
+                origin_header_names: None,
                 date_header: true,
             },
             &mut vec,
@@ -2595,6 +2613,7 @@ mod tests {
                 keep_alive: true,
                 req_method: &mut None,
                 title_case_headers: true,
+                origin_header_names: None,
                 date_header: true,
             },
             &mut vec,
@@ -2631,6 +2650,7 @@ mod tests {
                 keep_alive: true,
                 req_method: &mut None,
                 title_case_headers: false,
+                origin_header_names: None,
                 date_header: true,
             },
             &mut vec,
@@ -2667,6 +2687,7 @@ mod tests {
                 keep_alive: true,
                 req_method: &mut None,
                 title_case_headers: true,
+                origin_header_names: None,
                 date_header: true,
             },
             &mut vec,
@@ -2704,6 +2725,7 @@ mod tests {
                 keep_alive: true,
                 req_method: &mut None,
                 title_case_headers: true,
+                origin_header_names: None,
                 date_header: false,
             },
             &mut vec,


### PR DESCRIPTION
This PR introduces a way to pass a map of header names and their original names, something that should be used to resolve header name when sending requests.